### PR TITLE
Use GitHub as a source of plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Disable GitHub Multibranch Status Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Disable+GitHub+Multibranch+Status+Plugin</url>
+    <url>https://github.com/jenkinsci/disable-github-multibranch-status-plugin</url>
     <description>Adds support for disabling the GitHub status for a Multibranch pipeline job.</description>
     <licenses>
         <license>


### PR DESCRIPTION
AFAICT Wiki page does not exist, so the documentation is missing on GitHub: https://plugins.jenkins.io/disable-github-multibranch-status/ . we could just reuse what GitHub README already contains.

A release will be needed to deliver the change

FTR https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/